### PR TITLE
Make Newtonsoft.Json reference absolute

### DIFF
--- a/Discord RPC/DiscordRPC.csproj
+++ b/Discord RPC/DiscordRPC.csproj
@@ -104,7 +104,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.11.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.11.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
Use a SolutionDir macro (the base directory for NuGet packages) to make the reference to Newtonsoft.Json be absolute instead of relative. Once again, this will assist in making the project referenceable from other solutions.

In case you're curious what I'm doing with this: FayneAldan/SVRichPresence@55b737b 😝 