### PR TITLE
Fix a typo in the docs articles

### DIFF
--- a/docfx_project/articles/toc.yml
+++ b/docfx_project/articles/toc.yml
@@ -16,5 +16,5 @@
     href: join_spectate/join_requests.md
   - name: Joining Games
     href: join_spectate/join.md
-  - name: Specating Games
+  - name: Spectating Games
     href: join_spectate/spectate.md


### PR DESCRIPTION
`toc.yml` file inside the articles folder had a small one letter typo. ("Spectating Games" instead of "Specating Games")