### PR TITLE
Fixes pipe stream chunking

### DIFF
--- a/DiscordRPC/IO/PipeFrame.cs
+++ b/DiscordRPC/IO/PipeFrame.cs
@@ -127,11 +127,12 @@ namespace DiscordRPC.IO
 			//Read the contents
 			using (var mem = new MemoryStream())
 			{
-				byte[] buffer = new byte[Min(2048, len)]; // read in chunks of 2KB
+				uint chunkSize = (uint)Min(2048, len); // read in chunks of 2KB
+				byte[] buffer = new byte[chunkSize];
 				int bytesRead;
 				while ((bytesRead = stream.Read(buffer, 0, Min(buffer.Length, readsRemaining))) > 0)
 				{
-					readsRemaining -= len;
+					readsRemaining -= chunkSize;
 					mem.Write(buffer, 0, bytesRead);
 				}
 


### PR DESCRIPTION
Pipe chunking would never go over the 2048 max chunk size. This fixes that so it is actually read in chunks. You can validate by issuing a "GET_VOICE_SETTINGS" command to RPC which gives a pretty sizeable response, which in my case was larger than the 2048 chunk.