### PR TITLE
Added versioning to the Cake addins

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 // Addins
-#addin nuget:?package=Cake.FileHelpers
-#addin nuget:?package=Cake.Git
-#addin nuget:?package=Cake.VersionReader
+#addin nuget:?package=Cake.FileHelpers&version=4.0.1
+#addin nuget:?package=Cake.Git&version=1.1.0
+#addin nuget:?package=Cake.VersionReader&version=5.1.0
 
 // Adjustable Variables
 var projectName = "DiscordRPC";


### PR DESCRIPTION
This should fix the issue. I noticed that the cake adding was what was causing the issue, and the addins were updated between the last working build and the first erroring build. Adding versioning will ensure Cake will work in the future if the addins update again.

Should assist in fixing #171