### PR TITLE
Fix of ProcessMessage throwing NullPointerExceptions

### DIFF
--- a/DiscordRPC/DiscordRpcClient.cs
+++ b/DiscordRPC/DiscordRpcClient.cs
@@ -300,15 +300,13 @@ namespace DiscordRPC
                         if (pm != null)
                         {
                             //We need to merge these presences together
-                            if (CurrentPresence == null)
-                            {
-                                CurrentPresence = (new RichPresence()).Merge(pm.Presence);
-                            }
-                            else if (pm.Presence == null)
+                            if (pm.Presence == null)
                             {
                                 CurrentPresence = null;
-                            }
-                            else
+                            } else if (CurrentPresence == null)
+                            {
+                                CurrentPresence = (new RichPresence()).Merge(pm.Presence);
+                            } else
                             {
                                 CurrentPresence.Merge(pm.Presence);
                             }


### PR DESCRIPTION
## What the bug was
So, I kept getting NullReferenceExceptions thrown at me by the logger when the presence was activated on and off (testing behaviours for my own app when a user acts maliciously). Following the log (which I have since rather stupidly deleted), it showed that the exception was occuring at the ProcessMessage() method, which tried to merge the current presence with a possibly null one.

Since Merge() does not have null-checking, this caused the afforementioned NullReferenceException. To fix this is really easy - simply make sure that you have checked the incoming presence for null BEFORE checking whether the CURRENT presence is null (and therefore possibly causing a multitude of hair pulling bugs).