### PR TITLE
Fix ConsoleLogger throwing FormatException

### DIFF
--- a/DiscordRPC/Logging/ConsoleLogger.cs
+++ b/DiscordRPC/Logging/ConsoleLogger.cs
@@ -69,8 +69,18 @@ namespace DiscordRPC.Logging
             if (Level > LogLevel.Trace) return;
 
             if (Coloured) Console.ForegroundColor = ConsoleColor.Gray;
-            Console.WriteLine("TRACE: " + message, args);
-        }
+
+			string prefixedMessage = "TRACE: " + message;
+
+			if (args.Length > 0)
+			{
+				Console.WriteLine(prefixedMessage, args);
+			}
+			else
+			{
+				Console.WriteLine(prefixedMessage);
+			}
+		}
 
         /// <summary>
         /// Informative log messages
@@ -82,7 +92,17 @@ namespace DiscordRPC.Logging
 			if (Level > LogLevel.Info) return;
 
 			if (Coloured) Console.ForegroundColor = ConsoleColor.White;
-			Console.WriteLine("INFO: " + message, args);
+
+			string prefixedMessage = "INFO: " + message;
+
+			if (args.Length > 0)
+			{
+				Console.WriteLine(prefixedMessage, args);
+			}
+			else
+			{
+				Console.WriteLine(prefixedMessage);
+			}
 		}
 
 		/// <summary>
@@ -95,7 +115,17 @@ namespace DiscordRPC.Logging
 			if (Level > LogLevel.Warning) return;
 
 			if (Coloured) Console.ForegroundColor = ConsoleColor.Yellow;
-			Console.WriteLine("WARN: " + message, args);
+
+			string prefixedMessage = "WARN: " + message;
+
+			if (args.Length > 0)
+			{
+				Console.WriteLine(prefixedMessage, args);
+			}
+			else
+			{
+				Console.WriteLine(prefixedMessage);
+			}
 		}
 
 		/// <summary>
@@ -108,7 +138,17 @@ namespace DiscordRPC.Logging
 			if (Level > LogLevel.Error) return;
 
 			if (Coloured) Console.ForegroundColor = ConsoleColor.Red;
-			Console.WriteLine("ERR : " + message, args);
+
+			string prefixedMessage = "ERR : " + message;
+
+			if (args.Length > 0)
+			{
+				Console.WriteLine(prefixedMessage, args);
+			}
+			else
+			{
+				Console.WriteLine(prefixedMessage);
+			}
 		}
 
 	}


### PR DESCRIPTION
Fixes #207.

The issue are this lines in RpcConnection. When either the Exception Message, or the Stacktrace contains a brace (for example "{").

![grafik](https://user-images.githubusercontent.com/10519180/192825015-db9a0e97-65d3-4523-9b96-cc81528a9416.png)

I fixed it like in the FileLogger - only use the formatted version, when arguments are actually provided.