### PR TITLE
Fix deserialization of nullable field "premium_type"

### DIFF
--- a/DiscordRPC/User.cs
+++ b/DiscordRPC/User.cs
@@ -140,7 +140,7 @@ namespace DiscordRPC
         /// <summary>
         /// The premium type of the user.
         /// </summary>
-        [JsonProperty("premium_type")]
+        [JsonProperty("premium_type", NullValueHandling = NullValueHandling.Ignore)]
         public PremiumType Premium { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
I came across this issue because of increasing reports of users that their presence is not showing up lately. I guess the Discord API now actually omits the `premium_type` field at least if the user is not subscribed.

In VS i could not find any reference to this member of the User class, is it even used or could it be removed entirely?