### PR TITLE
Allows nullable fields to be ignored during JSON deserialization

### DIFF
--- a/DiscordRPC/User.cs
+++ b/DiscordRPC/User.cs
@@ -91,7 +91,7 @@ namespace DiscordRPC
         /// <summary>
         /// The flags on a users account, often represented as a badge.
         /// </summary>
-        [JsonProperty("flags")]
+        [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
         public Flag Flags { get; private set; }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace DiscordRPC
         /// <summary>
         /// The premium type of the user.
         /// </summary>
-        [JsonProperty("premium_type")]
+        [JsonProperty("premium_type", NullValueHandling = NullValueHandling.Ignore)]
         public PremiumType Premium { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
I have had some users provide some error messages like the following (account info redacted since it's irrelevant)

```
[ERROR]: Failed to process event! Error converting value {null} to type 'DiscordRPC.User+PremiumType'. Path 'user.premium_type'.
[ERROR]: Data: {"cmd":"DISPATCH","data":{"v":1,"config":{"cdn_host":"cdn.discordapp.com","api_endpoint":"//discord.com/api","environment":"production"},"user":{"id":"==REDACTED==","username":"==REDACTED==","discriminator":"==REDACTED==","avatar":"==REDACTED==","avatar_decoration":null,"bot":false,"flags":32,"premium_type":null}},"evt":"READY","nonce":null}
```

I have not been able to replicate this issue, however according to the documentation on the [Discord Developer Portal - Documentation | Users Resource](https://discord.com/developers/docs/resources/user) section, there are a handful of fields that can come in as null. This should make the library closer to spec and hopefully alleviate the issues my users are facing. Let me know if you want to discuss or if you have some way to test this before merging and releasing.

Thanks!