### PR TITLE
Reduce overhead in `ManagedNamedPipeClient` during connection loop

### DIFF
--- a/DiscordRPC/IO/ManagedNamedPipeClient.cs
+++ b/DiscordRPC/IO/ManagedNamedPipeClient.cs
@@ -140,6 +140,9 @@ namespace DiscordRPC.IO
                 {
                     Logger.Info("Attempting to connect to '{0}'", pipename);
                     _stream = new NamedPipeClientStream(".", pipename, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+                    // Intentionally use a timeout of 0 here to avoid spinlock overhead.
+                    // We are already performing local retry logic, so this is not required.
                     _stream.Connect(1000);
 
                     //Spin for a bit while we wait for it to finish connecting
@@ -378,7 +381,7 @@ namespace DiscordRPC.IO
                 return;
             }
 
-            //flush and dispose			
+            //flush and dispose
             try
             {
                 //Wait for the stream object to become available.

--- a/DiscordRPC/IO/ManagedNamedPipeClient.cs
+++ b/DiscordRPC/IO/ManagedNamedPipeClient.cs
@@ -143,7 +143,7 @@ namespace DiscordRPC.IO
 
                     // Intentionally use a timeout of 0 here to avoid spinlock overhead.
                     // We are already performing local retry logic, so this is not required.
-                    _stream.Connect(1000);
+                    _stream.Connect(0);
 
                     //Spin for a bit while we wait for it to finish connecting
                     Logger.Trace("Waiting for connection...");


### PR DESCRIPTION
The implementation of `NamedPipeClientStream` has some egregious use of `SpinOnce`:

https://github.com/dotnet/runtime/blob/d59af2cf097acb100ad6a9cba652be34be6f4a2e/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs#L151-L155

This adds perceivable overhead to the connect process, which we really don't want on a background thread. It is especially noticeable when discord is not running and the reconnect process is constantly running in the background.

To get around this, we can request a connect timeout of 0 ms from the underlying API. Checking the implementations, this seems like a valid method, as long as there is external retry logic in place (which there is in the local class).

Over 5 failed connection attempts:

| Before | After |
|:------:|:-----:|
| ![Parallels Desktop 2021-09 at 09 36 44](https://github.com/ppy/osu/assets/191335/251691ce-aa21-47de-8768-33a24d29add2) | ![Parallels Desktop 2023-07-12 at 09 34 33](https://github.com/ppy/osu/assets/191335/a8575d49-4348-4ece-a1cd-9cbc4ca82912) |

Note that this profiled view is considering *thread running time*, not *all* time. It does not include actual `Thread.Sleep` sleep time, and the overhead seen here is actual CPU time being used from spinlocking.

Tested on Windows, macOS and linux.