### PR TITLE
Update README.md about UWP, .NET MAUI, WIN UI 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@ If you wish to have barebones Unity3D implementation, you need to build the `Dis
 
 **UWP / .NET MAUI / WIN UI 3**
 
-In order to make this library work with the UWP applications, you need to define `runFullTrust` Capability inside of `Package.appxmanifest`. It's done this way because library loads external .exe in order to make library work.
+For now, the library doesn't work on UWP applications until we find the issue and fix it.
 
-Here is the example how to add `runFullTrust` to UWP application:
+In order to make this library work with the WIN UI 3 related applications such as .NET MAUI, you need to define `runFullTrust` Capability inside `Package.appxmanifest`.
+
+Here is an example of how to add `runFullTrust` to your WIN UI 3 application:
 
 `Package.appxmanifest`:
 
@@ -170,4 +172,4 @@ Here is the example how to add `runFullTrust` to UWP application:
 </Package>
 ```
 
-If you use .NET MAUI or WIN UI 3, it is automaticly puts `runFullTrust` capability.
+If you use .NET MAUI or WIN UI 3 template for C#, it automatically puts `runFullTrust` capability.

--- a/README.md
+++ b/README.md
@@ -146,3 +146,28 @@ dotnet build -c Release
 **Unity3D**
 
 If you wish to have barebones Unity3D implementation, you need to build the `DiscordRPC.dll`, the [Unity Named Pipes](https://github.com/Lachee/unity-named-pipes) Library and the [UnityNamedPipe.cs](https://github.com/Lachee/discord-rpc-csharp/blob/master/Unity%20Example/Assets/Discord%20RPC/Scripts/Control/UnityNamedPipe.cs). Put these in your own Unity Project and the `.dll`s in a folder called `Plugins`. 
+
+**UWP / .NET MAUI / WIN UI 3**
+
+In order to make this library work with the UWP applications, you need to define `runFullTrust` Capability inside of `Package.appxmanifest`. It's done this way because library loads external .exe in order to make library work.
+
+Here is the example how to add `runFullTrust` to UWP application:
+
+`Package.appxmanifest`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap">
+  ...
+    <Capabilities>
+	    <rescap:Capability Name="runFullTrust" />
+    </Capabilities>
+</Package>
+```
+
+If you use .NET MAUI or WIN UI 3, it is automaticly puts `runFullTrust` capability.


### PR DESCRIPTION
Fix of #236 
Problem was that UWP applications along with .NET MAUI and WIN UI 3 requires certain capabilites and trust in order to load this library, without it the library doesn't do anything, because UWP blocks all restricted movement of loading external .exe's. 

It doesn't fire any exception in the library, but after digging I figure out why this was the error. And again, error was in restrictions.

It's good to change README.md because, there can be people like me who don't understand why this doesn't work.

And until we will find out what capabilites we need to provide to UWP, it's okay to put `runFullTrust`, because that's the only way make it work.

I hope you understand that, waiting for the possible approve.