### PR TITLE
Add custom Rich Presence names

### DIFF
--- a/DiscordRPC.Example/Program.cs
+++ b/DiscordRPC.Example/Program.cs
@@ -23,6 +23,7 @@ namespace DiscordRPC.Example
         /// </summary>
         private static RichPresence presence = new RichPresence()
         {
+            Name = "Example project",
             Details = "Example Project 🎁",
             State = "csharp example",
             Assets = new Assets()
@@ -104,6 +105,7 @@ namespace DiscordRPC.Example
             // == Set the presence
             client.SetPresence(new RichPresence()
             {
+                Name = "A Basic Example",
                 Details = "A Basic Example",
                 State = "In Game",
                 Timestamps = Timestamps.FromTimeSpan(10),

--- a/DiscordRPC/DiscordRpcClient.cs
+++ b/DiscordRPC/DiscordRpcClient.cs
@@ -506,6 +506,13 @@ namespace DiscordRPC
         }
 
         /// <summary>
+        /// Updates only the <see cref="BaseRichPresence.Name"/> of the <see cref="CurrentPresence"/> and sends the updated presence to Discord. Returns the newly edited Rich Presence.
+        /// </summary>
+        /// <param name="name">The name of the Discord Rich Presence</param>
+        /// <returns>Updated Rich Presence</returns>
+        public RichPresence UpdateName(string name) => Update(p => p.Name = name);
+
+        /// <summary>
         /// Updates only the <see cref="BaseRichPresence.Type"/> of the <see cref="CurrentPresence"/> and sends the updated presence to Discord. Returns the newly edited Rich Presence.
         /// </summary>
         /// <param name="type">The type of the Rich Presence</param>

--- a/DiscordRPC/RichPresence.cs
+++ b/DiscordRPC/RichPresence.cs
@@ -883,6 +883,17 @@ namespace DiscordRPC
         }
 
         /// <summary>
+        /// Sets the name of the Rich Presence.
+        /// </summary>
+        /// <param name="name">The name of the Rich Presence application</param>
+        /// <returns>The modified rich presence</returns>
+        public RichPresence WithName(string name)
+        {
+            Name = name;
+            return this;
+        }
+        
+        /// <summary>
         /// Sets the type of the Rich Presence. See also <seealso cref="ActivityType"/>.
         /// </summary>
         /// <param name="type">The status type</param>

--- a/DiscordRPC/RichPresence.cs
+++ b/DiscordRPC/RichPresence.cs
@@ -14,6 +14,24 @@ namespace DiscordRPC
     public class BaseRichPresence
     {
         /// <summary>
+        /// The user's current Rich Presence name. For example, "League of Legends".
+        /// <para>Max 128 bytes</para>
+        /// </summary>
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string Name
+        {
+            get { return _name; }
+            set
+            {
+                if (!ValidateString(value, out _name, 128, Encoding.UTF8))
+                    throw new StringOutOfRangeException("Name", 0, 128);
+            }
+        }
+
+        /// <summary>Internal inner name string</summary>
+        protected internal string _name;
+        
+        /// <summary>
         /// The user's current <see cref="Party"/> status. For example, "Playing Solo" or "With Friends".
         /// <para>Max 128 bytes</para>
         /// </summary>
@@ -176,7 +194,7 @@ namespace DiscordRPC
             if (other == null)
                 return false;
 
-            if (State != other.State || Details != other.Details || Type != other.Type)
+            if (State != other.State || Details != other.Details || Type != other.Type || Name != other.Name)
                 return false;
 
             //Checks if the timestamps are different
@@ -934,6 +952,7 @@ namespace DiscordRPC
                 State = this._state != null ? _state.Clone() as string : null,
                 Details = this._details != null ? _details.Clone() as string : null,
                 Type = this.Type,
+                Name = this.Name,
 
                 Buttons = !HasButtons() ? null : this.Buttons.Clone() as Button[],
                 Secrets = !HasSecrets() ? null : new Secrets


### PR DESCRIPTION
Discord normally discards the Name property and replaces it with the name associated with the Discord Application. Projects such as [arRPC](https://github.com/OpenAsar/arrpc) from [OpenAsar](https://github.com/OpenAsar/) are more lenient on such restrictions. Clients using OpenAsar will have their Discord Rich Presence shown like the screenshot below if the commit is merged.

Normal Discord clients are unaffected by this change and modifying the property will do nothing for them (for now).

If the user has a normal Discord client:
![92359b9c-7610-484e-a03b-ef2e6f5087d2_15-10-2024](https://github.com/user-attachments/assets/3667e04a-cea9-4dcb-a5ef-39d29695b89f)


Confirmed working with arRPC via the BasicExample
```cs
            client.SetPresence(new RichPresence()
            {
                Name = "A test Example",
                Details = "A Basic Example",
                State = "In Game",
                Timestamps = Timestamps.FromTimeSpan(10),
                Buttons = new Button[]
                {
                    new Button() { Label = "Fish", Url = "https://lachee.dev/" }
                }
            });
```

Client running openAsar:
![d0b3b97e-45be-4bcd-b37a-fd8deb80ce6d_15-10-2024](https://github.com/user-attachments/assets/baa2cab5-0765-4ca0-a316-09479694e385)

The PR is similar to #255 though currently only targets openAsar users. Discord will probably allow this in the default client in the future.

Fixes #48