### PR TITLE
Implement Microsoft.Extensions.Logger Wrapper

### DIFF
--- a/DiscordRPC/DiscordRPC.csproj
+++ b/DiscordRPC/DiscordRPC.csproj
@@ -8,11 +8,15 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+    <DefineConstants>DISABLE_MSLOGGEREXTENSION</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/DiscordRPC/DiscordRpcClient.cs
+++ b/DiscordRPC/DiscordRpcClient.cs
@@ -7,6 +7,10 @@ using DiscordRPC.Registry;
 using DiscordRPC.RPC;
 using DiscordRPC.RPC.Commands;
 using System;
+#if !DISABLE_MSLOGGEREXTENSION
+using Hi3Helper.SharpDiscordRPC.DiscordRPC.Logging;
+using ILoggerMs = Microsoft.Extensions.Logging.ILogger;
+#endif
 
 namespace DiscordRPC
 {
@@ -206,6 +210,15 @@ namespace DiscordRPC
         /// <param name="applicationID">The ID of the application created at discord's developers portal.</param>
         public DiscordRpcClient(string applicationID) : this(applicationID, -1) { }
 
+#if !DISABLE_MSLOGGEREXTENSION
+        /// <summary>
+        /// Creates a new Discord RPC Client which can be used to send Rich Presence and receive Join / Spectate events.
+        /// </summary>
+        /// <param name="applicationID">The ID of the application created at discord's developers portal.</param>
+        /// <param name="logger">The logger used to report messages. Uses Microsoft's implementation of logging extension</param>
+        public DiscordRpcClient(string applicationID, ILoggerMs logger) : this(applicationID, -1, new MsILoggerWrapper(logger)) { }
+#endif
+
         /// <summary>
         /// Creates a new Discord RPC Client which can be used to send Rich Presence and receive Join / Spectate events. This constructor exposes more advance features such as custom NamedPipeClients and Loggers.
         /// </summary>
@@ -249,7 +262,7 @@ namespace DiscordRPC
             };
         }
 
-        #endregion
+#endregion
 
         #region Message Handling
         /// <summary>

--- a/DiscordRPC/Logging/MsILoggerWrapper.cs
+++ b/DiscordRPC/Logging/MsILoggerWrapper.cs
@@ -1,0 +1,89 @@
+#if !DISABLE_MSLOGGEREXTENSION
+using System;
+using Microsoft.Extensions.Logging;
+using ILogger    = Microsoft.Extensions.Logging.ILogger;
+using ILoggerRpc = DiscordRPC.Logging.ILogger;
+using LogLevel   = DiscordRPC.Logging.LogLevel;
+
+namespace Hi3Helper.SharpDiscordRPC.DiscordRPC.Logging
+{
+    /// <summary>
+    /// Wraps a <see cref="ILogger"/> to a <see cref="ILoggerRpc"/>
+    /// </summary>
+    public class MsILoggerWrapper : ILoggerRpc
+    {
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Creates a new instance of the MsILoggerWrapper
+        /// <inheritdoc cref="MsILoggerWrapper"/>
+        /// </summary>
+        /// <param name="logger">Logger interface to be wrapped</param>
+        public MsILoggerWrapper(ILogger logger)
+        {
+            _logger = logger;
+        }
+        
+        private static string FormatMessage(string message, params object[] args)
+        {
+            return string.Format(message, args);
+        }
+
+        /// <summary>
+        /// The level of logging to apply to this logger.
+        /// </summary>
+        public LogLevel Level { get; set; }
+
+        /// <summary>
+        /// Formats and writes a trace log message.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="args"></param>
+        public void Trace(string message, params object[] args)
+        {
+            _logger.LogTrace(FormatMessage(message), args);
+        }
+
+        /// <summary>
+        /// Informative log messages
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="args"></param>
+        public void Info(string message, params object[] args)
+        {
+            _logger.LogInformation(FormatMessage(message), args);
+        }
+
+        /// <summary>
+        /// Warning log messages
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="args"></param>
+        public void Warning(string message, params object[] args)
+        {
+            _logger.LogWarning(FormatMessage(message), args);
+        }
+
+        /// <summary>
+        /// Error log messages
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="args"></param>
+        public void Error(string message, params object[] args)
+        {
+            _logger.LogError(FormatMessage(message), args);
+        }
+
+        /// <summary>
+        /// Error log messages
+        /// </summary>
+        /// <param name="ex"></param>
+        /// <param name="message"></param>
+        /// <param name="args"></param>
+        public void Error(Exception ex, string message, params object[] args)
+        {
+            _logger.LogError(ex, FormatMessage(message), args);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Goal: Implement a wrapper for Microsoft's ILogger implementation

This is to make it easier for other project to start implementing this project as Microsoft's ILogger implementation is a standard. This PR is based on our project's implementation but modified to fit in the base repo TargetFrameworks

Unfortunately, I don't seem to able to implement it for net45 TargetFramework for some reason, so it's currently disabled with constants at the moment for that framework. A hand on that would be greatly appreciated.