### PR TITLE
Fix spelling mistake

### DIFF
--- a/DiscordRPC.Example/Program.cs
+++ b/DiscordRPC.Example/Program.cs
@@ -551,7 +551,7 @@ namespace DiscordRPC.Example
                     break;
 
                 default:
-                    Console.WriteLine("Unkown Command '{0}'. Try 'help' for a list of commands", command);
+                    Console.WriteLine("Unknown Command '{0}'. Try 'help' for a list of commands", command);
                     break;
             }
 

--- a/DiscordRPC/Message/ErrorMessage.cs
+++ b/DiscordRPC/Message/ErrorMessage.cs
@@ -46,8 +46,8 @@ namespace DiscordRPC.Message
 		NotImplemented = 10,
 
 		//Discord RPC error codes
-		///<summary>Unkown Discord error</summary>
-		UnkownError = 1000,
+		///<summary>Unknown Discord error</summary>
+		UnknownError = 1000,
 
 		///<summary>Invalid Payload received</summary>
 		InvalidPayload = 4000,

--- a/DiscordRPC/RPC/RpcConnection.cs
+++ b/DiscordRPC/RPC/RpcConnection.cs
@@ -559,7 +559,7 @@ namespace DiscordRPC.RPC
 						
 					//we have no idea what we were sent
 					default:
-						Logger.Error("Unkown frame was received! {0}", response.Command);
+						Logger.Error("Unknown frame was received! {0}", response.Command);
 						return;
 				}
 				return;
@@ -591,7 +591,7 @@ namespace DiscordRPC.RPC
 					EnqueueMessage(request);
 					break;
 
-				//Unkown dispatch event received. We should just ignore it.
+				//Unknown dispatch event received. We should just ignore it.
 				default:
 					Logger.Warning("Ignoring {0}", response.Event.Value);
 					break;

--- a/DiscordRPC/Registry/UriScheme.cs
+++ b/DiscordRPC/Registry/UriScheme.cs
@@ -84,7 +84,7 @@ namespace DiscordRPC.Registry
 #endif
 
                 default:
-                    _logger.Error("Unkown Platform: {0}", Environment.OSVersion.Platform);
+                    _logger.Error("Unknown Platform: {0}", Environment.OSVersion.Platform);
                     throw new PlatformNotSupportedException("Platform does not support registration.");
             }
 

--- a/Unity Example/Assets/Discord RPC/Plugins/DiscordRPC.XML
+++ b/Unity Example/Assets/Discord RPC/Plugins/DiscordRPC.XML
@@ -1396,8 +1396,8 @@
         <member name="F:DiscordRPC.Message.ErrorCode.NotImplemented">
             <summary>The functionality was not yet implemented</summary>
         </member>
-        <member name="F:DiscordRPC.Message.ErrorCode.UnkownError">
-            <summary>Unkown Discord error</summary>
+        <member name="F:DiscordRPC.Message.ErrorCode.UnknownError">
+            <summary>Unknown Discord error</summary>
         </member>
         <member name="F:DiscordRPC.Message.ErrorCode.InvalidPayload">
             <summary>Invalid Payload received</summary>


### PR DESCRIPTION
Fix spelling mistake: "Unkown error" --> "Unknown error".

I have randomly noticed this misspelling in osu!lazer.