### PR TITLE
Add StatusDisplayType Support

### DIFF
--- a/DiscordRPC/DiscordRpcClient.cs
+++ b/DiscordRPC/DiscordRpcClient.cs
@@ -511,6 +511,12 @@ namespace DiscordRPC
         /// <param name="type">The type of the Rich Presence</param>
         /// <returns>Updated Rich Presence</returns>
         public RichPresence UpdateType(ActivityType type) => Update(p => p.Type = type);
+        /// <summary>
+        /// Updates only the <see cref="BaseRichPresence.StatusDisplay"/> of the <see cref="CurrentPresence"/> and sends the updated presence to Discord. Returns the newly edited Rich Presence.
+        /// </summary>
+        /// <param name="type">The type to display on the status</param>
+        /// <returns>Updated Rich Presence</returns>
+        public RichPresence UpdateStatusDisplayType(StatusDisplayType type) => Update(p => p.StatusDisplay = type);
 
         /// <summary>
         /// Updates only the <see cref="RichPresence.Buttons"/> of the <see cref="CurrentPresence"/> and updates/removes the buttons. Returns the newly edited Rich Presence.

--- a/DiscordRPC/RichPresence.cs
+++ b/DiscordRPC/RichPresence.cs
@@ -79,6 +79,13 @@ namespace DiscordRPC
         /// </summary>
         [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
         public ActivityType Type { get; set; }
+        
+        /// <summary>
+        /// The display type for the status
+        /// </summary>
+        [JsonProperty("status_display_type", NullValueHandling = NullValueHandling.Ignore)]
+        public StatusDisplayType StatusDisplay { get; set; }
+        
 
         /// <summary>
         /// Marks the <see cref="Secrets.MatchSecret"/> as a game session with a specific beginning and end. It was going to be used as a form of notification, but was replaced with the join feature. It may potentially have use in the future, but it currently has no use.
@@ -250,6 +257,7 @@ namespace DiscordRPC
             presence.State = State;
             presence.Details = Details;
             presence.Type = Type;
+            presence.StatusDisplay = StatusDisplay;
 
             presence.Party = !HasParty() ? Party : null;
             presence.Secrets = !HasSecrets() ? Secrets : null;
@@ -817,6 +825,25 @@ namespace DiscordRPC
         /// </summary>
         Competing = 5
     }
+    
+    /// <summary>
+    /// Rich Presence Display type
+    /// </summary>
+    public enum StatusDisplayType
+    {
+        /// <summary>
+        /// Displays the rich presence name "Listening to Spotify"
+        /// </summary>
+        Name = 0,
+        /// <summary>
+        /// Displays the rich presence state "Listening to Rick Astley"
+        /// </summary>
+        State = 1,
+        /// <summary>
+        /// Displays the rich presence details "Listening to Never Gonna Give You Up"
+        /// </summary>
+        Details = 2,
+    }
 
     /// <summary>
     /// The Rich Presence structure that will be sent and received by Discord. Use this class to build your presence and update it appropriately.
@@ -872,6 +899,16 @@ namespace DiscordRPC
         public RichPresence WithType(ActivityType type)
         {
             Type = type;
+            return this;
+        }
+        /// <summary>
+        /// Sets the display type for the status. See also <seealso cref="StatusDisplayType"/>.
+        /// </summary>
+        /// <param name="statusDisplay"></param>
+        /// <returns>The modified Rich Presence.</returns>
+        public RichPresence WithStatusDisplay(StatusDisplayType statusDisplay)
+        {
+            StatusDisplay = statusDisplay;
             return this;
         }
 
@@ -934,6 +971,7 @@ namespace DiscordRPC
                 State = this._state != null ? _state.Clone() as string : null,
                 Details = this._details != null ? _details.Clone() as string : null,
                 Type = this.Type,
+                StatusDisplay = this.StatusDisplay,
 
                 Buttons = !HasButtons() ? null : this.Buttons.Clone() as Button[],
                 Secrets = !HasSecrets() ? null : new Secrets
@@ -977,6 +1015,7 @@ namespace DiscordRPC
             this._state = presence.State;
             this._details = presence.Details;
             this.Type = presence.Type;
+            this.StatusDisplay = presence.StatusDisplay;
             this.Party = presence.Party;
             this.Timestamps = presence.Timestamps;
             this.Secrets = presence.Secrets;


### PR DESCRIPTION
Discord recently added the ability to set an optional "status_display_type" field for RPC. This determines what text display on the member list status preview. This is useful for a lot of stuff such as music players that want to show the artist/track name instead of the player.

Attached below is an example using a slightly modified version of the included sample.

<img width="205" height="43" alt="image" src="https://github.com/user-attachments/assets/9d6e96e8-a304-40c7-b8b2-8938fe1b456e" />
<img width="306" height="111" alt="image" src="https://github.com/user-attachments/assets/5064351e-9543-4192-8d9f-5206062ae6e0" />
<img width="636" height="319" alt="image" src="https://github.com/user-attachments/assets/a9940f5c-33f4-4bca-ad11-3906fbdda864" />
