### PR TITLE
Abort connection attempts after reaching a set number of tries

### DIFF
--- a/DiscordRPC/DiscordRpcClient.cs
+++ b/DiscordRPC/DiscordRpcClient.cs
@@ -18,6 +18,20 @@ namespace DiscordRPC
     {
         #region Properties
 
+        /// <summary>
+        /// Maximal amount of tries before aborting connection. If -1, then limit isn't present.
+        /// </summary>
+        /// <remarks>15 should be optimal value (~70s)</remarks>
+        public int MaxConnectionTries
+        {
+            get { return _maxConnectionTries; }
+            set
+            {
+                _maxConnectionTries = value;
+                if (connection != null) connection.MaxConnectionTries = value;
+            }
+        }
+        private int _maxConnectionTries;
 
         /// <summary>
         /// Gets a value indicating if the client has registered a URI Scheme. If this is false, Join / Spectate events will fail.
@@ -41,7 +55,7 @@ namespace DiscordRPC
         public int ProcessID { get; private set; }
 
         /// <summary>
-        /// The maximum size of the message queue received from Discord. 
+        /// The maximum size of the message queue received from Discord.
         /// </summary>
         public int MaxQueueSize { get; private set; }
 
@@ -196,6 +210,11 @@ namespace DiscordRPC
         /// The RPC Connection has sent a message. Called before any other event and executed from the RPC Thread.
         /// </summary>
         public event OnRpcMessageEvent OnRpcMessage;
+
+        /// <summary>
+        /// Too many failed connection tries. You must reinitialize the client.
+        /// </summary>
+        public event OnTooMannyConnectionTriesEvent OnTooMannyConnectionTries;
         #endregion
 
         #region Initialization
@@ -214,7 +233,11 @@ namespace DiscordRPC
         /// <param name="logger">The logger used to report messages. If null, then a <see cref="NullLogger"/> will be created and logs will be ignored.</param>
         /// <param name="autoEvents">Should events be automatically invoked from the RPC Thread as they arrive from discord?</param>
         /// <param name="client">The pipe client to use and communicate to discord through. If null, the default <see cref="ManagedNamedPipeClient"/> will be used.</param>
-        public DiscordRpcClient(string applicationID, int pipe = -1, ILogger logger = null, bool autoEvents = true, INamedPipeClient client = null)
+        /// <param name="maxConnectionTries">
+        /// The maximum number of connection attempts before terminating.
+        /// Use -1 to disable the limit entirely. A value of 15 is typically optimal (~70 seconds).
+        /// </param>
+        public DiscordRpcClient(string applicationID, int pipe = -1, ILogger logger = null, bool autoEvents = true, INamedPipeClient client = null, int maxConnectionTries = -1)
         {
             //Make sure appID is NOT null.
             if (string.IsNullOrEmpty(applicationID))
@@ -227,6 +250,7 @@ namespace DiscordRPC
             HasRegisteredUriScheme = false;
             AutoEvents = autoEvents;
             SkipIdenticalPresence = true;
+            _maxConnectionTries = maxConnectionTries;
 
             //Prepare the logger
             _logger = logger ?? new NullLogger();
@@ -235,7 +259,8 @@ namespace DiscordRPC
             connection = new RpcConnection(ApplicationID, ProcessID, TargetPipe, client ?? new ManagedNamedPipeClient(), autoEvents ? 0 : 128U)
             {
                 ShutdownOnly = _shutdownOnly,
-                Logger = _logger
+                Logger = _logger,
+                MaxConnectionTries = _maxConnectionTries
             };
 
             //Subscribe to its event
@@ -403,6 +428,13 @@ namespace DiscordRPC
                 case MessageType.ConnectionFailed:
                     if (OnConnectionFailed != null)
                         OnConnectionFailed.Invoke(this, message as ConnectionFailedMessage);
+                    break;
+                
+                case MessageType.TooMannyConnectionTries:
+                    if (OnTooMannyConnectionTries != null)
+                        OnTooMannyConnectionTries.Invoke(this, message as TooManyConnectionTriesMessage);
+
+                    Deinitialize();
                     break;
 
                 //We got a message we dont know what to do with.

--- a/DiscordRPC/DiscordRpcClient.cs
+++ b/DiscordRPC/DiscordRpcClient.cs
@@ -214,7 +214,7 @@ namespace DiscordRPC
         /// <summary>
         /// Too many failed connection tries. You must reinitialize the client.
         /// </summary>
-        public event OnTooMannyConnectionTriesEvent OnTooMannyConnectionTries;
+        public event OnTooManyConnectionTriesEvent OnTooManyConnectionTries;
         #endregion
 
         #region Initialization
@@ -430,9 +430,9 @@ namespace DiscordRPC
                         OnConnectionFailed.Invoke(this, message as ConnectionFailedMessage);
                     break;
                 
-                case MessageType.TooMannyConnectionTries:
-                    if (OnTooMannyConnectionTries != null)
-                        OnTooMannyConnectionTries.Invoke(this, message as TooManyConnectionTriesMessage);
+                case MessageType.TooManyConnectionTries:
+                    if (OnTooManyConnectionTries != null)
+                        OnTooManyConnectionTries.Invoke(this, message as TooManyConnectionTriesMessage);
 
                     Deinitialize();
                     break;

--- a/DiscordRPC/Events.cs
+++ b/DiscordRPC/Events.cs
@@ -89,7 +89,7 @@ namespace DiscordRPC.Events
     /// </summary>
     /// <param name="sender">The Discord client handler that sent this event</param>
     /// <param name="args">The arguments supplied with the event</param>
-    public delegate void OnTooMannyConnectionTriesEvent(object sender, TooManyConnectionTriesMessage args);
+    public delegate void OnTooManyConnectionTriesEvent(object sender, TooManyConnectionTriesMessage args);
 
 
     /// <summary>

--- a/DiscordRPC/Events.cs
+++ b/DiscordRPC/Events.cs
@@ -84,6 +84,13 @@ namespace DiscordRPC.Events
     /// <param name="args">The arguments supplied with the event</param>
     public delegate void OnConnectionFailedEvent(object sender, ConnectionFailedMessage args);
 
+    /// <summary>
+    /// Too many failed connection tries. You must reinitialize the client.
+    /// </summary>
+    /// <param name="sender">The Discord client handler that sent this event</param>
+    /// <param name="args">The arguments supplied with the event</param>
+    public delegate void OnTooMannyConnectionTriesEvent(object sender, TooManyConnectionTriesMessage args);
+
 
     /// <summary>
     /// A RPC Message is received.

--- a/DiscordRPC/Message/MessageType.cs
+++ b/DiscordRPC/Message/MessageType.cs
@@ -63,6 +63,6 @@ namespace DiscordRPC.Message
 		/// <summary>
 		/// Too many failed connection tries. You must reinitialize the client.
 		/// </summary>
-		TooMannyConnectionTries
+		TooManyConnectionTries
 	}
 }

--- a/DiscordRPC/Message/MessageType.cs
+++ b/DiscordRPC/Message/MessageType.cs
@@ -35,7 +35,7 @@ namespace DiscordRPC.Message
 		/// The Discord Client has unsubscribed from an event.
 		/// </summary>
 		Unsubscribe,
-		
+
 		/// <summary>
 		/// The Discord Client wishes for this process to join a game.
 		/// </summary>
@@ -59,6 +59,10 @@ namespace DiscordRPC.Message
 		/// <summary>
 		/// Failed to establish any connection with discord. Discord is potentially not running?
 		/// </summary>
-		ConnectionFailed
+		ConnectionFailed,
+		/// <summary>
+		/// Too many failed connection tries. You must reinitialize the client.
+		/// </summary>
+		TooMannyConnectionTries
 	}
 }

--- a/DiscordRPC/Message/TooManyConnectionTriesMessage.cs
+++ b/DiscordRPC/Message/TooManyConnectionTriesMessage.cs
@@ -8,6 +8,6 @@ namespace DiscordRPC.Message
 		/// <summary>
 		/// The type of message received from discord
 		/// </summary>
-		public override MessageType Type { get { return MessageType.TooMannyConnectionTries; } }
+		public override MessageType Type { get { return MessageType.TooManyConnectionTries; } }
 	}
 }

--- a/DiscordRPC/Message/TooManyConnectionTriesMessage.cs
+++ b/DiscordRPC/Message/TooManyConnectionTriesMessage.cs
@@ -1,0 +1,13 @@
+namespace DiscordRPC.Message
+{
+	/// <summary>
+	/// Too many failed connection tries. You must reinitialize the client.
+	/// </summary>
+	public class TooManyConnectionTriesMessage : IMessage
+	{
+		/// <summary>
+		/// The type of message received from discord
+		/// </summary>
+		public override MessageType Type { get { return MessageType.TooMannyConnectionTries; } }
+	}
+}


### PR DESCRIPTION
This PR adds a way to automatically abort connection attempts after a set number of tries.

It allows users to choose whether the RPC should retry indefinitely or stop after a defined limit.

(My code editor seems to have swapped some spaces with tabs. If that's an issue, then I'll revert changes)