### PR TITLE
Document Joining

### DIFF
--- a/Docfx/articles/features/joining.md
+++ b/Docfx/articles/features/joining.md
@@ -2,23 +2,43 @@
 ## Parties
 Discord can show you and your friends in a party together for a specific game.
 
-todo: (xref:DiscordRPC.Party)
-todo: image of 2 people in a party
-todo: example code for parties
+![image of parties](https://i.lu.je/2025/firefox_cxOtJ1xrdJ.png)
+
+The (xref:DiscordRPC.Party) can be used to create parties and control their size. With helper functions such as (xref:DiscordRPC.DiscordRpcClient.UpdatePartySize(int)) you can dynamically update when players join and leave.
+```cs
+client.SetPresence(new()
+{
+    Details = "Party Example",
+    State = "In Game",
+    Party = new()
+    {
+        ID = "my-unique-party-id",
+        Privacy = Party.PrivacySetting.Private,
+        Size = 1,
+        Max = 4,
+    },
+});
+```
+The (xref:DiscordRPC.Party.ID) is a unique id (to your application) that tells Discord what party the user is currently in. When two users use the same ID, Discord will group them together.
+
+> [!TIP]
+> If the size is set larger than actual number of users sharing the ID, then a default "fake" user is displayed instead.
+>
+> This value is also synchronised across all clients with the same ID.
 
 ## Joining / Lobbies
-You can provide a way for users to invite others to play your game either directly or by having a "Join Game" / "Request to Join" button on your presence.
+Users can use your Rich Presence as a very basic invite / join system. As long as the Party is set, you are able to provide special secret that discord will share to other users.
 
 When accepted/joined, the other player's game will be launched and a (xref:DiscordRPC.DiscordRpcClient.OnJoin) will be called with the secret you provided in your presence.
 
-todo: image here of a invite
+![image of join button](https://i.lu.je/2025/Discord_dT7xxZDifj.png)
 
 > [!NOTE]
 > Rich Presence only sends your secret to the other player. Your game must be able to connect and manage lobbies itself.
 >
 > Check out [Steams Documentation](https://partner.steamgames.com/doc/features/multiplayer/matchmaking) for their lobbies.
 
-### 1. Launching your game
+### Launching your game
 Discord uses custom [URI Schemes](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes) to launch your game. It requires one to be set to show any of joining buttons.
 
 This library provides functionality to do this. Before initializing, use the RegisterScheme function:
@@ -33,15 +53,99 @@ client.RegisterUriScheme("657300");
 client.Initialize();
 ```
 
+> [!NOTE]
+> You need to register the URI scheme to see other user's Join button and invites.
+
 > [!WARNING]
 > MacOS requires schemes to be registered through [App Bundles](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app). This library cannot access your App Bundle and cannot automatically register **non-steam** games. 
 >
 > If you are publishing a MacOS game, you **must** provide either a `Steam App ID` or a custom uri scheme (such as `my-game://launch`) to the `RegisterUriScheme`. 
 
-### 2. Setting a Secret
+### Setting a Secret
+Users will connect to multiplayer sessions of your game using a shared secret. When a presence is set, you can designate a secret that will be shared with users who will use that to join.
 
-### 3. Accepting Requests
-todo (xref:DiscordRPC.DiscordRpcClient.OnJoinRequest)
+This library doesn't provide a mechanism to connect to multiplayer sessions (match making) and will be dependant on your game, engine, and networking stack.
 
-### 4. Joining
-todo (xref:DiscordRPC.DiscordRpcClient.OnJoin)
+These secrets should contain enough data to know who & how to connect to someone but shouldn't include sensitive data like IP addresses.
+
+As a basic example, consider this implementation:
+```cs
+client.SetPresence(new()
+{
+    Details = "Party Example",
+    State = "In Game",
+    Party = new() { /* .. Party Details .. */ },
+
+    //  This is how a launching app will figure out how to connect to the game.
+    Secrets = new()
+    {
+        Join = Lobby.CreateJoinToken(Lobby.current.ID)
+    },
+});
+
+```
+
+Note that `Lobby.current.ID` and `Lobby.CreateJoinToken()` will be up to your implementation. A naive approach would be a set password as the secret, but a better approach would be to use a signed key such as a [JWT](https://www.jwt.io/introduction#when-to-use-json-web-tokens) which contains a lobby ID and signed by the lobby host.
+
+### Joining
+When a Party and Secret are set and the **viewing** user has had the URI Scheme registered, Discord will display a "Join" button on the presence. 
+
+![join](https://i.lu.je/2025/Discord_dT7xxZDifj.png)
+
+When a user clicks the Join button, Discord will launch the application using the URI Scheme that you registered earlier. 
+
+Your application will then need to subscribe to (). Once subscribed, Discord will then send a Join message via the (xref:DiscordRPC.DiscordRpcClient.OnJoin) event. Once this event is received, use the secret from the event to join the lobby.
+
+Below is an example on this process:
+```cs
+client.Subscribe(EventType.Join);
+client.OnJoin += (object sender, JoinMessage args) =>  {
+    Lobby.JoinWithToken(args.Secret);
+};  
+```
+
+> [!WARNING]
+> We do not automatically subscribe to events. This library is primarily uesd for simple Rich Presence and the Joining is a feature generally only useful for Games.
+>
+> Because of this, by default this app will not receive Discord Join events. You must call the (xref:DiscordRPC.DiscordRpcClient.subscribe).
+
+> [!TIP]
+> You can directly invite users to play your game. They will see a game invitation like so, and if they have run the URI Scheme registration too, they will be able to launch from here.
+> 
+> ![invite button](https://i.lu.je/2025/Discord_ivzV8uc0F8.png)
+
+### Ask to Join
+To make your lobby a invite-only, set your (xref:DiscordRPC.Party.PrivacySetting) to `Private`.
+
+This will change the "Join" button to a "Ask To Join". Users can directly respond to this in Discord, or you can listen to this event and respond to it directly in game using the (xref:DiscordRPC.DiscordRpcClient.OnJoinRequested)
+
+![ask to join](https://i.lu.je/2025/Discord_P1f65SgZun.png)
+
+Subscribe to these events and use the (xref:DiscordRPC.DiscordRpcClient.Respond):
+
+```cs
+client.Subscribe(EventType.JoinRequest);
+client.OnJoinRequested += async (object sender, JoinRequestMessage args) => {
+    var result = await UI.ShowRequestToJoin(args.user); // Hypothetical UI system
+    client.Respond(args.User, result.accepted);
+};
+```
+
+## Spectating
+Spectating has been removed from Discord.
+
+## Code Example
+The [DiscordRPC.Example](https://github.com/Lachee/discord-rpc-csharp/blob/master/DiscordRPC.Example/Joining.cs) project contains a very basic example of the joining flow. Use 2 seperate clients as an example. 
+
+```sh
+# Run on the first pipe
+dotnet run --framework net9 --project DiscordRPC.Example --example=Joining --pipe=0
+
+# Run on the second pipe
+dotnet run --framework net9 --project DiscordRPC.Example --example=Joining --pipe=1
+```
+
+> [!NOTE]
+> While it does register a scheme, this example cannot launch properly because it just registers the dotnet runner. 
+>
+> This wont be a problem in a full application.

--- a/Docfx/articles/features/joining.md
+++ b/Docfx/articles/features/joining.md
@@ -1,0 +1,47 @@
+# Joining and Parties
+## Parties
+Discord can show you and your friends in a party together for a specific game.
+
+todo: (xref:DiscordRPC.Party)
+todo: image of 2 people in a party
+todo: example code for parties
+
+## Joining / Lobbies
+You can provide a way for users to invite others to play your game either directly or by having a "Join Game" / "Request to Join" button on your presence.
+
+When accepted/joined, the other player's game will be launched and a (xref:DiscordRPC.DiscordRpcClient.OnJoin) will be called with the secret you provided in your presence.
+
+todo: image here of a invite
+
+> [!NOTE]
+> Rich Presence only sends your secret to the other player. Your game must be able to connect and manage lobbies itself.
+>
+> Check out [Steams Documentation](https://partner.steamgames.com/doc/features/multiplayer/matchmaking) for their lobbies.
+
+### 1. Launching your game
+Discord uses custom [URI Schemes](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes) to launch your game. It requires one to be set to show any of joining buttons.
+
+This library provides functionality to do this. Before initializing, use the RegisterScheme function:
+```cs
+client.RegisterUriScheme();
+client.Initialize();
+```
+
+If you have a Steam game, you can launch using the `steam://` scheme instead by providing an appid:
+```cs
+client.RegisterUriScheme("657300");
+client.Initialize();
+```
+
+> [!WARNING]
+> MacOS requires schemes to be registered through [App Bundles](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app). This library cannot access your App Bundle and cannot automatically register **non-steam** games. 
+>
+> If you are publishing a MacOS game, you **must** provide either a `Steam App ID` or a custom uri scheme (such as `my-game://launch`) to the `RegisterUriScheme`. 
+
+### 2. Setting a Secret
+
+### 3. Accepting Requests
+todo (xref:DiscordRPC.DiscordRpcClient.OnJoinRequest)
+
+### 4. Joining
+todo (xref:DiscordRPC.DiscordRpcClient.OnJoin)

--- a/Docfx/articles/join_spectate/intro.md
+++ b/Docfx/articles/join_spectate/intro.md
@@ -1,5 +1,0 @@
-# Join / Spectate
-Discord Rich Presence can serve as a form of match maker for your game. You can display a "Join" and "Spectate" button on your Rich Presence to allow people to connect directly through discord.
-
-# Help Wanted Here
-Contribute with what you know and how you did it with a new PR on the [GitHub Repository](https://github.com/Lachee/discord-rpc-csharp)

--- a/Docfx/articles/join_spectate/join.md
+++ b/Docfx/articles/join_spectate/join.md
@@ -1,5 +1,0 @@
-# ToDo
-Documentation is current not written for this subject
-
-# Help Wanted Here
-Contribute with what you know and how you did it with a new PR on the [GitHub Repository](https://github.com/Lachee/discord-rpc-csharp)

--- a/Docfx/articles/join_spectate/join_requests.md
+++ b/Docfx/articles/join_spectate/join_requests.md
@@ -1,5 +1,0 @@
-# ToDo
-Documentation is current not written for this subject
-
-# Help Wanted Here
-Contribute with what you know and how you did it with a new PR on the [GitHub Repository](https://github.com/Lachee/discord-rpc-csharp)

--- a/Docfx/articles/join_spectate/spectate.md
+++ b/Docfx/articles/join_spectate/spectate.md
@@ -1,5 +1,0 @@
-# ToDo
-Documentation is current not written for this subject
-
-# Help Wanted Here
-Contribute with what you know and how you did it with a new PR on the [GitHub Repository](https://github.com/Lachee/discord-rpc-csharp)

--- a/Docfx/articles/toc.yml
+++ b/Docfx/articles/toc.yml
@@ -26,13 +26,5 @@
 - name: Timestamps
   href: features/timestamps.md
 
-- name: Join / Spectate
-  items:
-  - name: Introduction
-    href: join_spectate/intro.md
-  - name: Getting Requests
-    href: join_spectate/join_requests.md
-  - name: Joining Games
-    href: join_spectate/join.md
-  - name: Spectating Games
-    href: join_spectate/spectate.md
+- name: Joining & Parties
+  href: features/joining.md


### PR DESCRIPTION
Implemented the article for joining.
It could still be improved on, but it is a much better than what we currently have.

# AI Summary
This pull request restructures and significantly expands the documentation for Discord Rich Presence joining and party features. It replaces the previous minimal and incomplete "Join / Spectate" section with a comprehensive new guide under "Joining & Parties," providing detailed instructions, code examples, and explanations for implementing party, joining, and invite functionalities. The outdated spectating feature is also clarified as removed.

**Documentation Restructuring:**

* The "Join / Spectate" section and its four stub articles (`intro.md`, `join.md`, `join_requests.md`, `spectate.md`) have been removed from the documentation, eliminating incomplete and placeholder content. [[1]](diffhunk://#diff-f30c24eb09791f2b503b9b2bca97c9fc6344addd0961d74b40445726af548481L1-L5) [[2]](diffhunk://#diff-ef849ac8da65ce453a7ca3bcf6dbd15b5ae5d6993c69e8a104959588e6b67a73L1-L5)
* The table of contents `toc.yml` has been updated to replace "Join / Spectate" with the new "Joining & Parties" entry, pointing to the expanded documentation.

**Major Documentation Additions:**

* A new, in-depth article `features/joining.md` has been added, covering Discord parties, joining/lobbies, URI scheme registration, secrets for multiplayer sessions, event subscriptions, invite flows, and the removal of spectating. This includes practical code samples and implementation notes for developers.

**Feature Clarifications:**

* The documentation now clearly states that Discord no longer supports spectating, helping to set expectations for developers.

**Developer Guidance and Examples:**

* The new guide provides actionable tips, warnings (e.g., MacOS URI scheme registration requirements), and links to example projects and external resources to assist developers in implementing these features correctly.