### PR TITLE
Fix NullReferenceException in Assets.Merge when Discord sends null assets

### DIFF
--- a/DiscordRPC/Entities/Assets.cs
+++ b/DiscordRPC/Entities/Assets.cs
@@ -158,6 +158,26 @@ namespace DiscordRPC
 		/// <param name="other"></param>
 		internal void Merge(Assets other)
 		{
+            //Guard against Discord sending null assets in presence updates
+            if (other == null)
+            {
+                _smallimagetext = null;
+                _smallimageurl = null;
+                _largeimagetext = null;
+                _largeimageurl = null;
+
+                _largeimagekey = null;
+                _smallimagekey = null;
+
+                LargeImageID = null;
+                SmallImageID = null;
+
+                IsLargeImageKeyExternal = false;
+                IsSmallImageKeyExternal = false;
+
+                return;
+            }
+            
 			//Copy over the names
 			_smallimagetext = other._smallimagetext;
 			_smallimageurl = other._smallimageurl;


### PR DESCRIPTION
## Summary

This PR fixes a `NullReferenceException` thrown inside `Assets.Merge(Assets other)` when Discord sends presence updates where the assets payload is `null` or missing.

The bug does **not** prevent Rich Presence updates from being applied in the Discord client, but it does cause spurious error logs and can be confusing for users embedding the library in games or mods.

## Problem

`DiscordRpcClient.ProcessMessage` calls `RichPresence.Merge` to keep `CurrentPresence` in sync with incoming presence updates from Discord:

```csharp
if (presenceMessage.Presence == null)
{
    CurrentPresence = null;
}
else if (CurrentPresence == null)
{
    CurrentPresence = new RichPresence().Merge(presenceMessage.Presence);
}
else
{
    CurrentPresence.Merge(presenceMessage.Presence);
}
````

Inside `RichPresence.Merge`, assets are merged like this (simplified):

```csharp
if (presence.HasAssets())
{
    if (!HasAssets())
        Assets = presence.Assets;
    else
        Assets.Merge(presence.Assets);
}
else
{
    Assets = null;
}
```

When Discord sends a presence update **without assets**, `presence.Assets` can be `null`. In that situation, `Assets.Merge(presence.Assets)` is invoked with `other == null`, but `Assets.Merge` does not guard against this and unconditionally dereferences `other`:

```csharp
internal void Merge(Assets other)
{
    // uses other._smallimagetext, other._largeimagekey, etc...
}
```

This leads to a `NullReferenceException` similar to:

```text
Unhandled Exception while processing event: System.NullReferenceException
Object reference not set to an instance of an object.
   at DiscordRPC.Assets.Merge(Assets other)
   at DiscordRPC.RichPresence.Merge(BaseRichPresence presence)
   at DiscordRPC.DiscordRpcClient.ProcessMessage(IMessage message)
   at DiscordRPC.DiscordRpcClient.<.ctor>b__103_0(Object sender, IMessage msg)
   at DiscordRPC.RPC.RpcConnection.EnqueueMessage(IMessage message)
```

In practice:

* The Rich Presence update succeeds and is visible in the Discord client.
* The background RPC handling thread logs this exception whenever assets are cleared or updated in certain ways.

This is especially visible in game/mod environments where logs are surfaced prominently.

## Reproduction

One way to reproduce:

1. Set a Rich Presence with valid `Assets` (large/small images).
2. Later, send an updated presence that **clears** or removes assets (e.g. presence without any asset keys).
3. When Discord sends back the presence update, `Assets.Merge` may be called with `other == null`, triggering a `NullReferenceException` in the RPC event loop.

This can happen in real applications that dynamically toggle or clear presence images.

## Fix

The fix is minimal and fully backwards compatible:

* Add a guard clause at the beginning of `Assets.Merge(Assets other)` to handle `other == null`.
* When `other` is null, the method now resets local asset fields and returns early, effectively treating it as “clear all assets”.

```csharp
internal void Merge(Assets other)
{
    // Guard against Discord sending null assets in presence updates
    if (other == null)
    {
        _smallimagetext = null;
        _smallimageurl = null;
        _largeimagetext = null;
        _largeimageurl = null;

        _largeimagekey = null;
        _smallimagekey = null;

        LargeImageID = null;
        SmallImageID = null;

        IsLargeImageKeyExternal = false;
        IsSmallImageKeyExternal = false;

        return;
    }

    // rest...
}
```

This aligns with the idea that presence updates without assets should simply clear them instead of causing an exception.

## Impact

* No API changes.
* Existing behavior when `other != null` is unchanged.
* Presence updates without assets no longer cause `NullReferenceException` to be logged.
* The fix is compatible with all existing target frameworks, including `fx 4.5`, which is important for engines like Unity, MonoGame, Godot, and game mods embedding the library.

## Testing

* Built the library targeting `fx 4.5`.
* Integrated the patched `DiscordRPC.dll` into a game mod environment.
* Verified:

  * Rich Presence updates with and without assets work as expected.
  * Toggling/clearing images no longer produces `NullReferenceException` in the logs.
  * No regressions observed in normal Rich Presence behavior.