### PR TITLE
Add Vesktop as package manager entry

### DIFF
--- a/DiscordRPC/IO/PipeLocation.cs
+++ b/DiscordRPC/IO/PipeLocation.cs
@@ -17,6 +17,7 @@ namespace DiscordRPC.IO
 		{
 			"app/com.discordapp.Discord/",	// Flatpak
 			"snap.discord/",				// Snap
+            ".flatpak/dev.vencord.Vesktop/xdg-run" // Vesktop (Flatpak)
 			// TODO: Add more package managers as needed such as AppImage
 		};
 


### PR DESCRIPTION
I'm not sure if third-party Discord clients are allowed or if they should be put into another variable, but I've tested this and it works.